### PR TITLE
Remove duplicate DOI from target

### DIFF
--- a/src/main/java/eu/dissco/disscomasschedulerservice/repository/MasJobRecordRepository.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/repository/MasJobRecordRepository.java
@@ -39,7 +39,7 @@ public class MasJobRecordRepository {
         .set(MAS_JOB_RECORD.JOB_STATE, masJobRecord.state())
         .set(MAS_JOB_RECORD.MAS_ID, masJobRecord.masId())
         .set(MAS_JOB_RECORD.CREATOR, masJobRecord.agentId())
-        .set(MAS_JOB_RECORD.TARGET_ID, DOI_STRING + masJobRecord.targetId())
+        .set(MAS_JOB_RECORD.TARGET_ID, masJobRecord.targetId())
         .set(MAS_JOB_RECORD.TARGET_TYPE, masJobRecord.targetType())
         .set(MAS_JOB_RECORD.TIME_STARTED, now)
         .set(MAS_JOB_RECORD.BATCHING_REQUESTED, masJobRecord.batchingRequested())

--- a/src/main/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerService.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerService.java
@@ -149,7 +149,7 @@ public class MasSchedulerService {
     verifyTargetExists(mediaTargets, targetMapMedia, masRequests, failedMasJobRequests);
     return Stream.concat(targetMapSpecimens.entrySet().stream(), targetMapMedia.entrySet().stream())
         .filter(e -> e.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        .collect(Collectors.toMap(entry -> DOI_STRING + entry.getKey(), Map.Entry::getValue));
   }
 
   private void verifyTargetExists(Set<String> targetIds, Map<String, JsonNode> targetMap,

--- a/src/test/java/eu/dissco/disscomasschedulerservice/TestUtils.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/TestUtils.java
@@ -34,7 +34,9 @@ public class TestUtils {
   public static final String DOI = "https://doi.org/";
   public static final String MAS_ID = HANDLE + "/AAA-BBB-CCC";
   public static final String MAS_ID_ALT = HANDLE + "/XXX-YYY-ZZZ";
+  public static final String BARE_TARGET_DOI = PREFIX + "/111-222-333";
   public static final String TARGET_ID = DOI + PREFIX + "/111-222-333";
+  public static final String BARE_TARGET_ALT_DOI = PREFIX + "/111-222-334";
   public static final String TARGET_ID_ALT = DOI + PREFIX + "/111-222-334";
   public static final String JOB_ID = HANDLE + "/444-555-666";
   public static final String AGENT_ID = HANDLE + "/777-888-999";

--- a/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalMediaRepositoryIT.java
@@ -1,7 +1,7 @@
 package eu.dissco.disscomasschedulerservice.repository;
 
+import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.CREATED;
-import static eu.dissco.disscomasschedulerservice.TestUtils.DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
 import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenDateTimeFormatter;
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.Test;
 
 class DigitalMediaRepositoryIT extends BaseRepositoryIT {
 
-  private DigitalMediaRepository mediaRepository;
   private final DateTimeFormatter formatter = givenDateTimeFormatter();
+  private DigitalMediaRepository mediaRepository;
 
   @BeforeEach
   void setup() {
@@ -45,10 +45,10 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
         .put("dcterms:identifier", TARGET_ID)
         .put("dcterms:created", formatter.format(CREATED))
         .put("ods:version", 1);
-    var expected = Map.of(TARGET_ID.replace(DOI, ""), media);
+    var expected = Map.of(BARE_TARGET_DOI, media);
 
     // When
-    var result = mediaRepository.getMedia(Set.of(TARGET_ID.replace(DOI, "")));
+    var result = mediaRepository.getMedia(Set.of(BARE_TARGET_DOI));
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -56,7 +56,7 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
 
   private void insertIntoDatabase() throws JsonProcessingException {
     context.insertInto(DIGITAL_MEDIA_OBJECT)
-        .set(DIGITAL_MEDIA_OBJECT.ID, TARGET_ID.replace(DOI, ""))
+        .set(DIGITAL_MEDIA_OBJECT.ID, BARE_TARGET_DOI)
         .set(DIGITAL_MEDIA_OBJECT.VERSION, 1)
         .set(DIGITAL_MEDIA_OBJECT.TYPE, "ods:DigitalMeda")
         .set(DIGITAL_MEDIA_OBJECT.CREATED, CREATED)

--- a/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalSpecimenRepositoryIT.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalSpecimenRepositoryIT.java
@@ -1,8 +1,8 @@
 package eu.dissco.disscomasschedulerservice.repository;
 
 import static eu.dissco.disscomasschedulerservice.TestUtils.AGENT_ID;
+import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.CREATED;
-import static eu.dissco.disscomasschedulerservice.TestUtils.DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
 import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenDateTimeFormatter;
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test;
 
 class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
 
-  private DigitalSpecimenRepository specimenRepository;
   private final DateTimeFormatter formatter = givenDateTimeFormatter();
+  private DigitalSpecimenRepository specimenRepository;
 
   @BeforeEach
   void setup() {
@@ -46,10 +46,10 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
         .put("ods:midsLevel", (short) 1)
         .put("dcterms:created", formatter.format(CREATED))
         .put("ods:version", 1);
-    var expected = Map.of(TARGET_ID.replace(DOI, ""), specimen);
+    var expected = Map.of(BARE_TARGET_DOI, specimen);
 
     // When
-    var result = specimenRepository.getSpecimens(Set.of(TARGET_ID.replace(DOI, "")));
+    var result = specimenRepository.getSpecimens(Set.of(BARE_TARGET_DOI));
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -57,7 +57,7 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
 
   private void insertIntoDatabase() throws JsonProcessingException {
     context.insertInto(DIGITAL_SPECIMEN)
-        .set(DIGITAL_SPECIMEN.ID, TARGET_ID.replace(DOI, ""))
+        .set(DIGITAL_SPECIMEN.ID, BARE_TARGET_DOI)
         .set(DIGITAL_SPECIMEN.VERSION, 1)
         .set(DIGITAL_SPECIMEN.TYPE, "ods:DigitalSpecimen")
         .set(DIGITAL_SPECIMEN.MIDSLEVEL, (short) 1)

--- a/src/test/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerServiceTest.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerServiceTest.java
@@ -1,6 +1,8 @@
 package eu.dissco.disscomasschedulerservice.service;
 
 import static eu.dissco.disscomasschedulerservice.TestUtils.AGENT_ID;
+import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_ALT_DOI;
+import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.HANDLE;
 import static eu.dissco.disscomasschedulerservice.TestUtils.JOB_ID;
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
@@ -74,6 +76,29 @@ class MasSchedulerServiceTest {
   @Mock
   private Environment environment;
 
+  private static Stream<Arguments> provideFilters() {
+    return Stream.of(
+        Arguments.of(givenFiltersDigitalSpecimen()),
+        Arguments.of(
+            new OdsHasTargetDigitalObjectFilter()
+                .withAdditionalProperty("$['ods:fdoType']", List.of("Some Test value"))),
+        Arguments.of(new OdsHasTargetDigitalObjectFilter()
+            .withAdditionalProperty("$['ods:format']", List.of("application/json"))),
+        Arguments.of(new OdsHasTargetDigitalObjectFilter()
+            .withAdditionalProperty(
+                "$['ods:hasEvents'][*]['ods:hasLocation']['dwc:country']",
+                List.of("The Netherlands", "Belgium"))),
+        Arguments.of(new OdsHasTargetDigitalObjectFilter()
+            .withAdditionalProperty(
+                "$['ods:hasEvents'][*]['eco:protocolDescriptions']",
+                List.of("Diopsis camera"))),
+        Arguments.of(new OdsHasTargetDigitalObjectFilter()
+            .withAdditionalProperty("$['ods:hasEvents'][*]['dwc:city']",
+                List.of("Rotterdam", "Amsterdam"))),
+        Arguments.of(new OdsHasTargetDigitalObjectFilter()
+            .withAdditionalProperty("$['omg:someRandomNonExistingKey']", List.of("Nothing")))
+    );
+  }
 
   @BeforeEach
   void init() {
@@ -101,8 +126,8 @@ class MasSchedulerServiceTest {
     );
     given(handleComponent.postHandle(4)).willReturn(handles);
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalSpecimen(TARGET_ID),
-        TARGET_ID_ALT, givenDigitalSpecimen(TARGET_ID_ALT)
+        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID),
+        BARE_TARGET_ALT_DOI, givenDigitalSpecimen(TARGET_ID_ALT)
     ));
 
     // When
@@ -190,7 +215,7 @@ class MasSchedulerServiceTest {
             }
         """);
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, digitalSpecimen
+        BARE_TARGET_DOI, digitalSpecimen
     ));
     var masRequest = new MasJobRequest(
         MAS_ID,
@@ -226,7 +251,7 @@ class MasSchedulerServiceTest {
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(environment.matchesProfiles(Profiles.WEB)).willReturn(false);
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
+        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
     ));
     doThrow(PidCreationException.class).when(handleComponent).postHandle(anyInt());
 
@@ -245,7 +270,7 @@ class MasSchedulerServiceTest {
     var masRequest = givenMasJobRequest();
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
+        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
     ));
     given(environment.matchesProfiles(Profiles.WEB)).willReturn(true);
     doThrow(PidCreationException.class).when(handleComponent).postHandle(anyInt());
@@ -298,7 +323,7 @@ class MasSchedulerServiceTest {
         MAS_ID, TARGET_ID, true, AGENT_ID, MjrTargetType.DIGITAL_SPECIMEN);
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
+        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
     ));
     given(environment.matchesProfiles(Profiles.WEB)).willReturn(true);
 
@@ -344,7 +369,7 @@ class MasSchedulerServiceTest {
         MAS_ID, TARGET_ID, false, AGENT_ID, MjrTargetType.MEDIA_OBJECT
     );
     given(mediaRepository.getMedia(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalMedia(TARGET_ID)
+        BARE_TARGET_DOI, givenDigitalMedia(TARGET_ID)
     ));
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)
         .withOdsHasTargetDigitalObjectFilter(givenFiltersDigitalMedia())));
@@ -369,7 +394,7 @@ class MasSchedulerServiceTest {
     var masRequest = givenMasJobRequest();
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
+        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
     ));
     given(handleComponent.postHandle(1)).willReturn(List.of(JOB_ID));
     doThrow(JsonProcessingException.class).when(publisherService).publishMasJob(any(), any());
@@ -389,7 +414,7 @@ class MasSchedulerServiceTest {
     var masRequest = givenMasJobRequest();
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
+        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
     ));
     given(handleComponent.postHandle(1)).willReturn(List.of(JOB_ID));
     doThrow(JsonProcessingException.class).when(publisherService).publishMasJob(any(), any());
@@ -402,30 +427,6 @@ class MasSchedulerServiceTest {
     // Then
     then(masJobRecordRepository).should().markMasJobRecordsAsFailed(List.of(JOB_ID));
     then(publisherService).shouldHaveNoMoreInteractions();
-  }
-
-  private static Stream<Arguments> provideFilters() {
-    return Stream.of(
-        Arguments.of(givenFiltersDigitalSpecimen()),
-        Arguments.of(
-            new OdsHasTargetDigitalObjectFilter()
-                .withAdditionalProperty("$['ods:fdoType']", List.of("Some Test value"))),
-        Arguments.of(new OdsHasTargetDigitalObjectFilter()
-            .withAdditionalProperty("$['ods:format']", List.of("application/json"))),
-        Arguments.of(new OdsHasTargetDigitalObjectFilter()
-            .withAdditionalProperty(
-                "$['ods:hasEvents'][*]['ods:hasLocation']['dwc:country']",
-                List.of("The Netherlands", "Belgium"))),
-        Arguments.of(new OdsHasTargetDigitalObjectFilter()
-            .withAdditionalProperty(
-                "$['ods:hasEvents'][*]['eco:protocolDescriptions']",
-                List.of("Diopsis camera"))),
-        Arguments.of(new OdsHasTargetDigitalObjectFilter()
-            .withAdditionalProperty("$['ods:hasEvents'][*]['dwc:city']",
-                List.of("Rotterdam", "Amsterdam"))),
-        Arguments.of(new OdsHasTargetDigitalObjectFilter()
-            .withAdditionalProperty("$['omg:someRandomNonExistingKey']", List.of("Nothing")))
-    );
   }
 
 }


### PR DESCRIPTION
https://naturalis.atlassian.net/browse/DD-2077
Ok the issue was indeed a double domain for the target.
This was in the database and caused the issue: `https://doi.org/https://doi.org/TEST/SFE-5BY-VST`
The code assumed the ID for the object would be without the domain but it actually comes with the domain.
I also needed to change the map to include the domain in the key ID's that are in there.
When it requests the database it requests it without the domain which is good (db is without domain).
But then it used directly used the ID column value (without domain) as key for the map.