### PR TITLE
remove proxy

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,3 +1,0 @@
-# Aug 18 - Spring needs to update
-# Issue with netty
-CVE-2025-55163

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/disscomasschedulerservice/controller/MasSchedulerController.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/controller/MasSchedulerController.java
@@ -1,5 +1,7 @@
 package eu.dissco.disscomasschedulerservice.controller;
 
+import static eu.dissco.disscomasschedulerservice.repository.RepositoryUtils.DOI_STRING;
+
 import eu.dissco.disscomasschedulerservice.Profiles;
 import eu.dissco.disscomasschedulerservice.domain.MasJobRequest;
 import eu.dissco.disscomasschedulerservice.exception.InvalidRequestException;
@@ -35,6 +37,11 @@ public class MasSchedulerController {
         masJobRequest.masId(),
         masJobRequest.targetId(),
         masJobRequest.agentId());
+    masJobRequest = new MasJobRequest(masJobRequest.masId(),
+        masJobRequest.targetId().replace(DOI_STRING, ""),
+        masJobRequest.batching(),
+        masJobRequest.agentId(),
+        masJobRequest.targetType());
     masSchedulerService.scheduleMass(Set.of(masJobRequest));
     log.info("MAS {} Scheduled", masJobRequest.masId());
     return ResponseEntity.status(HttpStatus.ACCEPTED).build();

--- a/src/main/java/eu/dissco/disscomasschedulerservice/domain/MasJobRequest.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/domain/MasJobRequest.java
@@ -2,12 +2,16 @@ package eu.dissco.disscomasschedulerservice.domain;
 
 
 import eu.dissco.disscomasschedulerservice.database.jooq.enums.MjrTargetType;
+import jakarta.validation.constraints.NotNull;
 
 public record MasJobRequest(
+    @NotNull
     String masId,
+    @NotNull
     String targetId,
     boolean batching,
     String agentId,
+    @NotNull
     MjrTargetType targetType
 ) {
 

--- a/src/main/java/eu/dissco/disscomasschedulerservice/domain/MasJobRequest.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/domain/MasJobRequest.java
@@ -1,11 +1,13 @@
 package eu.dissco.disscomasschedulerservice.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import eu.dissco.disscomasschedulerservice.database.jooq.enums.MjrTargetType;
 import jakarta.validation.constraints.NotNull;
 
 public record MasJobRequest(
     @NotNull
+    @JsonPropertyDescription("Identifier of MAS. May include proxy")
     String masId,
     @NotNull
     String targetId,

--- a/src/main/java/eu/dissco/disscomasschedulerservice/domain/MasJobRequest.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/domain/MasJobRequest.java
@@ -1,13 +1,10 @@
 package eu.dissco.disscomasschedulerservice.domain;
 
-
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import eu.dissco.disscomasschedulerservice.database.jooq.enums.MjrTargetType;
 import jakarta.validation.constraints.NotNull;
 
 public record MasJobRequest(
     @NotNull
-    @JsonPropertyDescription("Identifier of MAS. May include proxy")
     String masId,
     @NotNull
     String targetId,

--- a/src/main/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerService.java
+++ b/src/main/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerService.java
@@ -1,7 +1,5 @@
 package eu.dissco.disscomasschedulerservice.service;
 
-import static eu.dissco.disscomasschedulerservice.repository.RepositoryUtils.DOI_STRING;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.jayway.jsonpath.JsonPath;
@@ -28,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -136,12 +135,10 @@ public class MasSchedulerService {
     var specimenTargets = masRequests.stream()
         .filter(masRequest -> masRequest.targetType().equals(MjrTargetType.DIGITAL_SPECIMEN))
         .map(MasJobRequest::targetId)
-        .map(id -> id.replace(DOI_STRING, ""))
         .collect(Collectors.toSet());
     var mediaTargets = masRequests.stream()
         .filter(masRequest -> masRequest.targetType().equals(MjrTargetType.MEDIA_OBJECT))
         .map(MasJobRequest::targetId)
-        .map(id -> id.replace(DOI_STRING, ""))
         .collect(Collectors.toSet());
     var targetMapSpecimens = new HashMap<>(specimenRepository.getSpecimens(specimenTargets));
     var targetMapMedia = new HashMap<>(mediaRepository.getMedia(mediaTargets));
@@ -149,7 +146,7 @@ public class MasSchedulerService {
     verifyTargetExists(mediaTargets, targetMapMedia, masRequests, failedMasJobRequests);
     return Stream.concat(targetMapSpecimens.entrySet().stream(), targetMapMedia.entrySet().stream())
         .filter(e -> e.getValue() != null)
-        .collect(Collectors.toMap(entry -> DOI_STRING + entry.getKey(), Map.Entry::getValue));
+        .collect(Collectors.toMap(Entry::getKey, Map.Entry::getValue));
   }
 
   private void verifyTargetExists(Set<String> targetIds, Map<String, JsonNode> targetMap,

--- a/src/test/java/eu/dissco/disscomasschedulerservice/TestUtils.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/TestUtils.java
@@ -34,10 +34,9 @@ public class TestUtils {
   public static final String DOI = "https://doi.org/";
   public static final String MAS_ID = HANDLE + "/AAA-BBB-CCC";
   public static final String MAS_ID_ALT = HANDLE + "/XXX-YYY-ZZZ";
-  public static final String BARE_TARGET_DOI = PREFIX + "/111-222-333";
-  public static final String TARGET_ID = DOI + PREFIX + "/111-222-333";
-  public static final String BARE_TARGET_ALT_DOI = PREFIX + "/111-222-334";
-  public static final String TARGET_ID_ALT = DOI + PREFIX + "/111-222-334";
+  public static final String TARGET_ID = PREFIX + "/111-222-333";
+  public static final String TARGET_ID_WITH_PROXY = DOI + TARGET_ID;
+  public static final String TARGET_ID_ALT = PREFIX + "/111-222-334";
   public static final String JOB_ID = HANDLE + "/444-555-666";
   public static final String AGENT_ID = HANDLE + "/777-888-999";
 

--- a/src/test/java/eu/dissco/disscomasschedulerservice/TestUtils.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/TestUtils.java
@@ -30,15 +30,15 @@ public class TestUtils {
   public static final ObjectMapper MAPPER;
   public static final Instant CREATED = Instant.parse("2022-11-01T09:59:24.00Z");
   public static final String PREFIX = "20.5000.1025";
-  public static final String HANDLE = "https://hdl.handle.net/" + PREFIX;
+  public static final String HANDLE = "https://hdl.handle.net/";
   public static final String DOI = "https://doi.org/";
-  public static final String MAS_ID = HANDLE + "/AAA-BBB-CCC";
-  public static final String MAS_ID_ALT = HANDLE + "/XXX-YYY-ZZZ";
+  public static final String MAS_ID = HANDLE + PREFIX + "/AAA-BBB-CCC";
+  public static final String MAS_ID_ALT = HANDLE + PREFIX + "/XXX-YYY-ZZZ";
   public static final String TARGET_ID = PREFIX + "/111-222-333";
   public static final String TARGET_ID_WITH_PROXY = DOI + TARGET_ID;
   public static final String TARGET_ID_ALT = PREFIX + "/111-222-334";
-  public static final String JOB_ID = HANDLE + "/444-555-666";
-  public static final String AGENT_ID = HANDLE + "/777-888-999";
+  public static final String JOB_ID = HANDLE + PREFIX + "/444-555-666";
+  public static final String AGENT_ID = HANDLE + PREFIX + "/777-888-999";
 
   public static final int TTL_DEFAULT = 86400;
 
@@ -82,7 +82,8 @@ public class TestUtils {
     );
   }
 
-  public static MasTarget givenMasTarget(String targetId, String jobId) throws JsonProcessingException {
+  public static MasTarget givenMasTarget(String targetId, String jobId)
+      throws JsonProcessingException {
     return new MasTarget(
         givenDigitalSpecimen(targetId),
         jobId,
@@ -178,11 +179,12 @@ public class TestUtils {
         .withSchemaCodeRepository("https://github.com/DiSSCo/fancy-mas")
         .withSchemaProgrammingLanguage("Java")
         .withOdsServiceAvailability("public")
-        .withSchemaMaintainer(new Agent().withType(Type.SCHEMA_SOFTWARE_APPLICATION).withId(AGENT_ID))
+        .withSchemaMaintainer(
+            new Agent().withType(Type.SCHEMA_SOFTWARE_APPLICATION).withId(AGENT_ID))
         .withSchemaLicense("https://www.apache.org/licenses/LICENSE-2.0")
         .withSchemaContactPoint(new SchemaContactPoint().withSchemaEmail("dontmail@dissco.eu"))
         .withOdsSlaDocumentation("https://www.know.dissco.tech/no_sla")
-        .withOdsTopicName(masId)
+        .withOdsTopicName(masId.replace(HANDLE, ""))
         .withOdsBatchingPermitted(batching)
         .withOdsTimeToLive(TTL_DEFAULT);
   }

--- a/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalMediaRepositoryIT.java
@@ -1,9 +1,9 @@
 package eu.dissco.disscomasschedulerservice.repository;
 
-import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.CREATED;
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
 import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID;
+import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID_WITH_PROXY;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenDateTimeFormatter;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenDigitalMedia;
 import static eu.dissco.disscomasschedulerservice.database.jooq.Tables.DIGITAL_MEDIA_OBJECT;
@@ -41,14 +41,14 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
     insertIntoDatabase();
     var media = (ObjectNode) givenDigitalMedia(TARGET_ID);
     media
-        .put("@id", TARGET_ID)
-        .put("dcterms:identifier", TARGET_ID)
+        .put("@id", TARGET_ID_WITH_PROXY)
+        .put("dcterms:identifier", TARGET_ID_WITH_PROXY)
         .put("dcterms:created", formatter.format(CREATED))
         .put("ods:version", 1);
-    var expected = Map.of(BARE_TARGET_DOI, media);
+    var expected = Map.of(TARGET_ID, media);
 
     // When
-    var result = mediaRepository.getMedia(Set.of(BARE_TARGET_DOI));
+    var result = mediaRepository.getMedia(Set.of(TARGET_ID));
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -56,7 +56,7 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
 
   private void insertIntoDatabase() throws JsonProcessingException {
     context.insertInto(DIGITAL_MEDIA_OBJECT)
-        .set(DIGITAL_MEDIA_OBJECT.ID, BARE_TARGET_DOI)
+        .set(DIGITAL_MEDIA_OBJECT.ID, TARGET_ID)
         .set(DIGITAL_MEDIA_OBJECT.VERSION, 1)
         .set(DIGITAL_MEDIA_OBJECT.TYPE, "ods:DigitalMeda")
         .set(DIGITAL_MEDIA_OBJECT.CREATED, CREATED)

--- a/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalSpecimenRepositoryIT.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/repository/DigitalSpecimenRepositoryIT.java
@@ -1,10 +1,10 @@
 package eu.dissco.disscomasschedulerservice.repository;
 
 import static eu.dissco.disscomasschedulerservice.TestUtils.AGENT_ID;
-import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.CREATED;
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
 import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID;
+import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID_WITH_PROXY;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenDateTimeFormatter;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenDigitalSpecimen;
 import static eu.dissco.disscomasschedulerservice.database.jooq.Tables.DIGITAL_SPECIMEN;
@@ -41,15 +41,15 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
     insertIntoDatabase();
     var specimen = (ObjectNode) givenDigitalSpecimen(TARGET_ID);
     specimen
-        .put("@id", TARGET_ID)
-        .put("dcterms:identifier", TARGET_ID)
+        .put("@id", TARGET_ID_WITH_PROXY)
+        .put("dcterms:identifier", TARGET_ID_WITH_PROXY)
         .put("ods:midsLevel", (short) 1)
         .put("dcterms:created", formatter.format(CREATED))
         .put("ods:version", 1);
-    var expected = Map.of(BARE_TARGET_DOI, specimen);
+    var expected = Map.of(TARGET_ID, specimen);
 
     // When
-    var result = specimenRepository.getSpecimens(Set.of(BARE_TARGET_DOI));
+    var result = specimenRepository.getSpecimens(Set.of(TARGET_ID));
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -57,7 +57,7 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
 
   private void insertIntoDatabase() throws JsonProcessingException {
     context.insertInto(DIGITAL_SPECIMEN)
-        .set(DIGITAL_SPECIMEN.ID, BARE_TARGET_DOI)
+        .set(DIGITAL_SPECIMEN.ID, TARGET_ID)
         .set(DIGITAL_SPECIMEN.VERSION, 1)
         .set(DIGITAL_SPECIMEN.TYPE, "ods:DigitalSpecimen")
         .set(DIGITAL_SPECIMEN.MIDSLEVEL, (short) 1)

--- a/src/test/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerServiceTest.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerServiceTest.java
@@ -132,8 +132,9 @@ class MasSchedulerServiceTest {
     masSchedulerService.scheduleMass(masJobRequests);
 
     // Then
-    then(publisherService).should(times(2)).publishMasJob(eq(MAS_ID), any());
-    then(publisherService).should(times(2)).publishMasJob(eq(MAS_ID_ALT), any());
+    then(publisherService).should(times(2)).publishMasJob(eq(MAS_ID.replace(HANDLE, "")), any());
+    then(publisherService).should(times(2))
+        .publishMasJob(eq(MAS_ID_ALT.replace(HANDLE, "")), any());
     then(masJobRecordRepository).should().createNewMasJobRecord(anyList());
   }
 
@@ -382,7 +383,7 @@ class MasSchedulerServiceTest {
     masSchedulerService.scheduleMass(Set.of(masRequest));
 
     // Then
-    then(publisherService).should().publishMasJob(MAS_ID, expected);
+    then(publisherService).should().publishMasJob(MAS_ID.replace(HANDLE, ""), expected);
     then(masJobRecordRepository).should().createNewMasJobRecord(anyList());
   }
 

--- a/src/test/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerServiceTest.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/service/MasSchedulerServiceTest.java
@@ -1,8 +1,6 @@
 package eu.dissco.disscomasschedulerservice.service;
 
 import static eu.dissco.disscomasschedulerservice.TestUtils.AGENT_ID;
-import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_ALT_DOI;
-import static eu.dissco.disscomasschedulerservice.TestUtils.BARE_TARGET_DOI;
 import static eu.dissco.disscomasschedulerservice.TestUtils.HANDLE;
 import static eu.dissco.disscomasschedulerservice.TestUtils.JOB_ID;
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
@@ -126,8 +124,8 @@ class MasSchedulerServiceTest {
     );
     given(handleComponent.postHandle(4)).willReturn(handles);
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID),
-        BARE_TARGET_ALT_DOI, givenDigitalSpecimen(TARGET_ID_ALT)
+        TARGET_ID, givenDigitalSpecimen(TARGET_ID),
+        TARGET_ID_ALT, givenDigitalSpecimen(TARGET_ID_ALT)
     ));
 
     // When
@@ -215,7 +213,7 @@ class MasSchedulerServiceTest {
             }
         """);
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, digitalSpecimen
+        TARGET_ID, digitalSpecimen
     ));
     var masRequest = new MasJobRequest(
         MAS_ID,
@@ -251,7 +249,7 @@ class MasSchedulerServiceTest {
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(environment.matchesProfiles(Profiles.WEB)).willReturn(false);
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
+        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
     ));
     doThrow(PidCreationException.class).when(handleComponent).postHandle(anyInt());
 
@@ -270,7 +268,7 @@ class MasSchedulerServiceTest {
     var masRequest = givenMasJobRequest();
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
+        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
     ));
     given(environment.matchesProfiles(Profiles.WEB)).willReturn(true);
     doThrow(PidCreationException.class).when(handleComponent).postHandle(anyInt());
@@ -323,7 +321,7 @@ class MasSchedulerServiceTest {
         MAS_ID, TARGET_ID, true, AGENT_ID, MjrTargetType.DIGITAL_SPECIMEN);
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
+        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
     ));
     given(environment.matchesProfiles(Profiles.WEB)).willReturn(true);
 
@@ -369,7 +367,7 @@ class MasSchedulerServiceTest {
         MAS_ID, TARGET_ID, false, AGENT_ID, MjrTargetType.MEDIA_OBJECT
     );
     given(mediaRepository.getMedia(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalMedia(TARGET_ID)
+        TARGET_ID, givenDigitalMedia(TARGET_ID)
     ));
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)
         .withOdsHasTargetDigitalObjectFilter(givenFiltersDigitalMedia())));
@@ -394,7 +392,7 @@ class MasSchedulerServiceTest {
     var masRequest = givenMasJobRequest();
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
+        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
     ));
     given(handleComponent.postHandle(1)).willReturn(List.of(JOB_ID));
     doThrow(JsonProcessingException.class).when(publisherService).publishMasJob(any(), any());
@@ -414,7 +412,7 @@ class MasSchedulerServiceTest {
     var masRequest = givenMasJobRequest();
     given(masRepository.getMasRecords(Set.of(MAS_ID))).willReturn(List.of(givenMas(MAS_ID)));
     given(specimenRepository.getSpecimens(anySet())).willReturn(Map.of(
-        BARE_TARGET_DOI, givenDigitalSpecimen(TARGET_ID)
+        TARGET_ID, givenDigitalSpecimen(TARGET_ID)
     ));
     given(handleComponent.postHandle(1)).willReturn(List.of(JOB_ID));
     doThrow(JsonProcessingException.class).when(publisherService).publishMasJob(any(), any());

--- a/src/test/java/eu/dissco/disscomasschedulerservice/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/disscomasschedulerservice/web/HandleComponentTest.java
@@ -1,7 +1,7 @@
 package eu.dissco.disscomasschedulerservice.web;
 
 import static eu.dissco.disscomasschedulerservice.TestUtils.MAPPER;
-import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID;
+import static eu.dissco.disscomasschedulerservice.TestUtils.TARGET_ID_WITH_PROXY;
 import static eu.dissco.disscomasschedulerservice.TestUtils.givenPostHandleResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -54,7 +54,7 @@ class HandleComponentTest {
   void testPostHandle() throws Exception {
     // Given
     var responseBody = givenPostHandleResponse(1);
-    var expected = List.of(TARGET_ID);
+    var expected = List.of(TARGET_ID_WITH_PROXY);
     mockHandleServer.enqueue(new MockResponse().setResponseCode(HttpStatus.OK.value())
         .setBody(MAPPER.writeValueAsString(responseBody))
         .addHeader("Content-Type", "application/json"));
@@ -102,7 +102,7 @@ class HandleComponentTest {
     var response = handleComponent.postHandle(1);
 
     // Then
-    assertThat(response).isEqualTo(List.of(TARGET_ID));
+    assertThat(response).isEqualTo(List.of(TARGET_ID_WITH_PROXY));
     assertThat(mockHandleServer.getRequestCount() - requestCount).isEqualTo(2);
   }
 


### PR DESCRIPTION
There was an expectation that the target ID would have the proxy in the request, and that we needed the proxy to compare target IDs to the results from the db. However, the specimen processor doesn't send a targetID with a proxy, and the db doesn't return an id with a proxy (at least not in the ID field). 

Changed the filtering so that we now reliably compare IDs without proxies. 

Also added some @NotNull constraints so we don't hit a NPE. 


I remove the DOI proxy in the controller just to be safe. 

MAS ID -> expects proxy 
Agent ID -> should have proxy (doesn't matter, there is no lookup on this value in this service)
Target ID -> no proxy (If it is included in web requests, we remove it)

I don't love how targetID shouldn't have a proxy but MAS ID should but I don't really want to mess with proxy stuff more than I need to. 


